### PR TITLE
Fix pagination object

### DIFF
--- a/ps3t_game_list.php
+++ b/ps3t_game_list.php
@@ -83,16 +83,9 @@
         // Set number of pages dynamically
         $init_html = file_get_html('http://www.' . $siteurl . '/browsegames/' . $gametype[$i] . '/' . $gamealpha . '/');
         
-        if ($gamesite == 'ps3t') {
-            $table_object = $init_html->find('div.bl_la_main div.divtext table', 1);
-            $page_object = $table_object->find('td', 0);
-            $page_num = substr(explode(" ", $page_object)[4], 0, -3); }
-
-        else {
-            $pagination_obj = $init_html->find('div.pagination a');
-            if (count($pagination_obj) == 0) { $page_num = 1; }
-            else { $page_num = $pagination_obj[count($pagination_obj)-2]->plaintext; }
-        }
+        $pagination_obj = $init_html->find('div.pagination a');
+        if (count($pagination_obj) == 0) { $page_num = 1; }
+        else { $page_num = $pagination_obj[count($pagination_obj)-2]->plaintext; }
         
         $init_html->clear();
         unset($init_html);


### PR DESCRIPTION
Pagination per letter was just updated on PST. This change will remove the logic for PST/XBA in favor of using the XBA logic only (which is now the only correct pagination.